### PR TITLE
Prefer the first occurrence of the product string in getVersion.

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -82,6 +82,8 @@ class DetectorBase(object):
     def getVersion(self, agent):
         # -> version string /None
         parts = agent.split(self.look_for + self.version_splitters[0])
+        if len(parts) == 1:
+            return None
         return parts[min(len(parts) - 1, 1)].split(self.version_splitters[1])[0].strip()
 
 

--- a/tests.py
+++ b/tests.py
@@ -77,6 +77,9 @@ data = (
 ("Mozilla/5.0 (X11; Linux x86_64; rv:7.0.1) Gecko/20111011 Firefox/7.0.1 SeaMonkey/2.4.1",
     ("Linux", "SeaMonkey 2.4.1"),
     {"os" : {"name": "Linux"}, "browser": {"name": "SeaMonkey", "version": "2.4.1"}}),
+("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:16.0) Gecko/20100101 Firefox/16.0",
+    ("Ubuntu Linux", "Firefox 16.0"),
+    {'dist': {'name': 'Ubuntu'}, 'os': {'name': 'Linux'}, 'browser': {'version': '16.0', 'name': 'Firefox'}},),
 )
 
 class TestHAP(unittest.TestCase):


### PR DESCRIPTION
According to the spec [0], the first occurrence of the product string
should be favoured when determining the actual product version. The
existing implementation favoured the last one, which broke on UAs like
this:

Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0;
Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; SLCC1; .NET
CLR 2.0.50727; InfoPath.1; .NET CLR 3.5.30729; .NET CLR 3.0.30618;
.NET4.0C)

Which is actually MSIE8, not MSIE6.

Fixed a test case that looks like it was broken with this very issue
while I was in the area, and added the one I was having problems with.

[0] http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
