### PR TITLE
Add support for mobile android browser

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -211,7 +211,7 @@ class Safari(Browser):
     look_for = "Safari"
 
     def checkWords(self, agent):
-        unless_list = ["Chrome", "OmniWeb", "wOSBrowser"]
+        unless_list = ["Chrome", "OmniWeb", "wOSBrowser", "Android"]
         if self.look_for in agent:
             for word in unless_list:
                 if word in agent:
@@ -225,6 +225,12 @@ class Safari(Browser):
             return agent.split('Safari/')[-1].split(' ')[0].strip()
         else:
             return agent.split('Safari ')[-1].split(' ')[0].strip()  # Mobile Safari
+
+
+class AndroidBrowser(Browser):
+    look_for = "Android"
+    skip_if_found = ["Chrome"]
+    version_splitters = [" ", ";"]
 
 
 class Linux(OS):


### PR DESCRIPTION
I believe there's a bug with OS detection. The old default browser on Android sends a useragent string like this: "Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30", and the inclusion of Safari trips detect into thinking its Safari. 

My change adds "Safari" to the the list skipped words in Safari::checkWords and creates a new OS subclass to detect the AndroidBrowser.
