### PR TITLE
Not actually fast

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,6 @@ Features
 --------
 
 - Works on Python 2.5+ and Python 3
-- Fast
 - Detects OS and Browser. Does not aim to be a full featured agent parser
 - Will not turn into django-httpagentparser ;)
 


### PR DESCRIPTION
I use this library on my logfiles.
Half of the time is spent looking up IP addresses in a on-disk database, the other half is spent in httpagentparser.
The time spent parsing the log file is marginal.

This change is obviously meant as a joke, but I suggest you do some profiling. Or I might even do some myself.
