### PR TITLE
Use tox to test specified Python versions.

### DIFF
--- a/dev-notes.rst
+++ b/dev-notes.rst
@@ -38,3 +38,10 @@ Build and upload new version
 
 - Bump __version__ in httpagentparser/__init__.py
 - python setup.py sdist upload
+
+Test httpagentparser
+====================
+To test httpagentparser from some Python versions, execute the command below (`tox <https://pypi.python.org/pypi/tox>`_ is required).
+
+- python setup.py test
+- (or python -m tox)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,41 @@
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
+import sys
+
+
+class Tox(TestCommand):
+    """ Running tox from setup.py.
+    See:
+    https://testrun.org/tox/latest/example/basic.html#integration-with-setuptools-distribute-test-commands
+    """
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def __init__(self, dist, **kw):
+        TestCommand.__init__(self, dist, **kw)
+        self.tox_args = None
+        self.test_args = []
+        self.test_suite = True
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import tox
+        import shlex
+
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
+
 
 for line in open('httpagentparser/__init__.py'):
     if line.startswith('__version__'):
@@ -21,5 +58,7 @@ setup(
     author_email='pythonic@gmail.com',
     license="http://www.opensource.org/licenses/mit-license.php",
     test_suite="tests",
+    tests_require=['tox'],
+    cmdclass={'test': Tox},
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py25, py26, py27, py33, py34
+
+[testenv]
+commands = tests.py


### PR DESCRIPTION
Hello
It's nice that supports both Python 2/3.
To test both versions easily, tox is a good solution.

This pull request enables to use tox to execute tests from specified Python versions:
2.5, 2.6, 2.7, 3.3, 3.4 (written in tox.ini)

usage:
  python setup.py test
  python -m tox

Thanks.