### PR TITLE
Fix a bug in fill_none=True

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -649,13 +649,10 @@ def detect(agent, fill_none=False):
                 pass
 
     if fill_none:
-        attrs_d = {'name': None, 'version': None}
-        for key in ('os', 'browser'):
-            if key not in result:
-                result[key] = attrs_d
-            else:
-                for k, v in attrs_d.items():
-                    result[k] = v
+        for outer_key in ('os', 'browser'):
+            outer_value = result.setdefault(outer_key, dict())
+            for inner_key in ('name', 'version'):
+                outer_value.setdefault(inner_key, None)
 
     return result
 

--- a/tests.py
+++ b/tests.py
@@ -201,8 +201,13 @@ class TestHAP(unittest.TestCase):
         self.assertEqual(detect(''), {'platform': {'version': None, 'name': None}})  # default
         self.assertEqual(detect('', fill_none=False), {'platform': {'version': None, 'name': None}})
         result = detect('', fill_none=True)
-        self.assertEqual(result['os'].get('name'), None)
-        self.assertEqual(result['browser'].get('version'), None)
+        self.assertEqual(result['os']['name'], None)
+        self.assertEqual(result['browser']['version'], None)
+        result = detect('Linux; Android', fill_none=True)
+        self.assertEqual(result['os']['name'], 'Linux')
+        self.assertEqual(result['os']['version'], None)
+        self.assertEqual(result['browser']['name'], 'AndroidBrowser')
+        self.assertEqual(result['browser']['version'], None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It works when 'os' or 'browser' is completely missing - but not if it's present, but missing 'name' or 'version'.