### PR TITLE
Return correct version for Android when user agent contains no device name after OS version

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -595,7 +595,7 @@ class Android(Dist):
     skip_if_found = ['Windows Phone']
 
     def getVersion(self, agent, word):
-        return agent.split(word)[-1].split(';')[0].strip()
+        return agent.split(word)[-1].replace(')', ';').split(';')[0].strip()
 
 
 class WebOS(Dist):


### PR DESCRIPTION
Fixes #82.