### PR TITLE
Fix RuntimeError: dictionary changed size during iteration

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -31,7 +31,8 @@ class DetectorsHub(dict):
         return iter(self._known_types)
 
     def registerDetectors(self):
-        detectors = [v() for v in globals().values() if DetectorBase in getattr(v, '__mro__', [])]
+        globals_copy = globals().copy()
+        detectors = [v() for v in globals_copy.values() if DetectorBase in getattr(v, '__mro__', [])]
         for d in detectors:
             if d.can_register:
                 self.register(d)

--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -31,8 +31,7 @@ class DetectorsHub(dict):
         return iter(self._known_types)
 
     def registerDetectors(self):
-        globals_copy = globals().copy()
-        detectors = [v() for v in globals_copy.values() if DetectorBase in getattr(v, '__mro__', [])]
+        detectors = [v() for v in list(globals().values()) if DetectorBase in getattr(v, '__mro__', [])]
         for d in detectors:
             if d.can_register:
                 self.register(d)


### PR DESCRIPTION
### Description
This attempts to address situations where `globals()` changed during iteration.
```
    import httpagentparser
  File "/.virtualenv/lib/python3.6/site-packages/httpagentparser/__init__.py", line 647, in <module>
    detectorshub = DetectorsHub()
  File "/.virtualenv/lib/python3.6/site-packages/httpagentparser/__init__.py", line 21, in __init__
    self.registerDetectors()
  File "/.virtualenv/lib/python3.6/site-packages/httpagentparser/__init__.py", line 34, in registerDetectors
    detectors = [v() for v in globals().values() if DetectorBase in getattr(v, '__mro__', [])]
  File "/.virtualenv/lib/python3.6/site-packages/httpagentparser/__init__.py", line 34, in <listcomp>
    detectors = [v() for v in globals().values() if DetectorBase in getattr(v, '__mro__', [])]
RuntimeError: dictionary changed size during iteration
```
It occurred during start up of a multi-threaded Flask app.

### Approach
Iterate a list copy of `globals().values()` instead.