### PR TITLE
Add more flexibilty to API functions

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -671,6 +671,10 @@ def detect(agent, fill_none=False):
     return result
 
 
+UNKNOWN_OS_NAME = 'Unknown OS'
+UNKNOWN_BROWSER_NAME = 'Unknown Browser'
+
+
 def simple_detect_tuple(agent, parsed_agent=None):
     """
     @params:
@@ -690,10 +694,10 @@ def simple_detect_tuple(agent, parsed_agent=None):
     if 'os' in result:
         os_list.append(result['os']['name'])
 
-    os = os_list and " ".join(os_list) or "Unknown OS"
+    os = os_list and " ".join(os_list) or UNKNOWN_OS_NAME
     os_version = os_list and (result.get('flavor') and result['flavor'].get('version')) or \
         (result.get('dist') and result['dist'].get('version')) or (result.get('os') and result['os'].get('version')) or ""
-    browser = 'browser' in result and result['browser'].get('name') or 'Unknown Browser'
+    browser = 'browser' in result and result['browser'].get('name') or UNKNOWN_BROWSER_NAME
     browser_version = 'browser' in result and result['browser'].get('version') or ""
 
     return os, os_version, browser, browser_version

--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -671,11 +671,17 @@ def detect(agent, fill_none=False):
     return result
 
 
-def simple_detect(agent):
+def simple_detect_tuple(agent, parsed_agent=None):
     """
-    -> (os, browser) # tuple of strings
+    @params:
+        agent::str
+        parsed_agent::dict
+            The result of detect, used to save calculations
+
+    @return:
+        (os_name, os_version, browser_name, browser_version)::Tuple(str)
     """
-    result = detect(agent)
+    result = parsed_agent or detect(agent)
     os_list = []
     if 'flavor' in result:
         os_list.append(result['flavor']['name'])
@@ -689,6 +695,21 @@ def simple_detect(agent):
         (result.get('dist') and result['dist'].get('version')) or (result.get('os') and result['os'].get('version')) or ""
     browser = 'browser' in result and result['browser'].get('name') or 'Unknown Browser'
     browser_version = 'browser' in result and result['browser'].get('version') or ""
+
+    return os, os_version, browser, browser_version
+
+
+def simple_detect(agent, parsed_agent=None):
+    """
+    @params:
+        agent::str
+        parsed_agent::dict
+            The result of detect, used to save calculations
+
+    @return:
+        (os_name_version, browser_name_version)::Tuple(str)
+    """
+    os, os_version, browser, browser_version = simple_detect_tuple(agent, parsed_agent=parsed_agent)
     if browser_version:
         browser = " ".join((browser, browser_version))
     if os_version:


### PR DESCRIPTION
We needed a simple way to get the browser name without the version.

And we used the unknown browser name as an actual browser name, so the ideal thing is to import that name from the library.