### PR TITLE
Add detecting Firefox on iOS.

### DIFF
--- a/httpagentparser/__init__.py
+++ b/httpagentparser/__init__.py
@@ -218,7 +218,7 @@ class WOSBrowser(Browser):
 
 class Safari(Browser):
     look_for = "Safari"
-    skip_if_found = ["Edge", "YaBrowser"]
+    skip_if_found = ["Edge", "YaBrowser", "FxiOS"]
 
     def checkWords(self, agent):
         unless_list = ["Chrome", "OmniWeb", "wOSBrowser", "Android", "CriOS"]
@@ -408,7 +408,7 @@ class AndroidBrowser(Browser):
 
 
 class Firefox(Browser):
-    look_for = "Firefox"
+    look_for = ["Firefox", "FxiOS"]
     version_markers = [('/', '')]
     skip_if_found = ["SeaMonkey", "web/snippet"]
 

--- a/tests.py
+++ b/tests.py
@@ -176,6 +176,9 @@ data = (
 ('Mozilla/5.0 (Linux; Android 8.1.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36',
     ('Android Linux 8.1.0', 'Chrome 76.0.3809.111'),
     {'os': {'name': 'Linux'}, 'bot': False, 'dist': {'version': '8.1.0', 'name': 'Android'}, 'browser': {'version': '76.0.3809.111', 'name': 'Chrome'}}),
+("Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/102.0 Mobile/15E148 Safari/605.1.15",
+    ('iPhone iOS 12.4', 'Firefox 102.0'),
+    {'os': {'name': 'iOS'}, "dist": {'name': 'iPhone', 'version': '12.4'}, 'bot': False, 'browser': {'name': 'Firefox', 'version': '102.0'}}),
 )
 
 class TestHAP(unittest.TestCase):


### PR DESCRIPTION
According to Mozilla documentation, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#focus_for_ios user agent for iOS devices is FxiOS.