### PR TITLE
Docs: Update CONTRIBUTING.md with modern build instructions and remove tox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,16 +34,11 @@ print(hap.simple_detect(s))
 
 # Build and upload new version
 
-- Bump `__version__` in `httpagentparser/__init__.py`
-- `python -m build`
-- `python -m twine upload dist/*`
+1. Bump `__version__` in `httpagentparser/__init__.py`
+2. Install modern build and upload tools: `python -m pip install build twine`
+3. Build the package: `python -m build`
+4. Upload to PyPI: `python -m twine upload dist/*`
 
 # Test httpagentparser
 
 - `python tests.py`
-
-## Tox
-
-To test httpagentparser from some Python versions, execute the command below (`tox` is required).
-
-- `python -m tox`

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,0 @@
-[tox]
-envlist = py36, py37, py38, py39, py310, py311, py312
-
-[testenv]
-commands = python tests.py


### PR DESCRIPTION
- Renames `dev-notes.md` to `CONTRIBUTING.md`.
- Updates the build and upload instructions to explicitly mention `python -m pip install build twine`.
- Formats build and upload instructions as numbered list steps.
- Drops outdated instructions for testing with `tox` and removes `tox.ini`.

---
*PR created automatically by Jules for task [5175293531554435952](https://jules.google.com/task/5175293531554435952) started by @shon*